### PR TITLE
Add animated wave support with UI toggle and speed control

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -33,6 +33,8 @@ def wave():
     gradient  = request.args.get("gradient", "false").lower() == "true"
     mirror    = request.args.get("mirror", "false").lower() == "true"
     opacity   = min(max(float(request.args.get("opacity", 1)), 0.1), 1)
+    animate   = request.args.get("animate", "false").lower() == "true"
+    speed     = min(max(float(request.args.get("speed", 6)), 1), 20)
 
     svg = generate_wave_svg(
         wave_type=wave_type,
@@ -47,6 +49,8 @@ def wave():
         gradient=gradient,
         mirror=mirror,
         opacity=opacity,
+        animate=animate,
+        speed=speed,
     )
 
     return Response(

--- a/api/wavegen.py
+++ b/api/wavegen.py
@@ -162,6 +162,8 @@ def generate_wave_svg(
     gradient: bool = False,
     opacity: float = 1.0,
     mirror: bool = False,
+    animate: bool = False,
+    speed: float = 6.0,
     smooth: bool = True,
 ) -> str:
     """
@@ -173,6 +175,7 @@ def generate_wave_svg(
     frequency = min(max(frequency, 0.5), 8.0)
     layers = min(max(layers, 1), 3)
     opacity = min(max(opacity, 0.1), 1.0)
+    speed = min(max(speed, 1.0), 20.0)
 
     r1, g1, b1 = _hex_to_rgb(color_top)
     r2, g2, b2 = _hex_to_rgb(color_bottom)
@@ -253,7 +256,20 @@ def generate_wave_svg(
                 y_offset=0.5,
             )
 
-        paths_svg += f'  <path d="{path_d}" fill="{layer_color}" fill-opacity="{layer_opacity:.2f}"/>\n'
+        animation_svg = ""
+        if animate:
+            layer_duration = speed + layer_idx * 1.1
+            layer_shift = width * (0.02 + layer_idx * 0.01)
+            animation_svg = (
+                f'<animateTransform attributeName="transform" type="translate" '
+                f'values="0 0; {-layer_shift:.2f} 0; 0 0" dur="{layer_duration:.2f}s" '
+                f'repeatCount="indefinite"/>'
+            )
+
+        paths_svg += (
+            f'  <path d="{path_d}" fill="{layer_color}" fill-opacity="{layer_opacity:.2f}">'
+            f'{animation_svg}</path>\n'
+        )
 
     # Mirror layer
     if mirror:
@@ -271,7 +287,17 @@ def generate_wave_svg(
                 fill_bottom=not flip,
                 y_offset=0.5,
             )
-        paths_svg += f'  <path d="{mirror_path}" fill="{fill_color}" fill-opacity="{opacity * 0.4:.2f}"/>\n'
+        mirror_anim = ""
+        if animate:
+            mirror_anim = (
+                f'<animateTransform attributeName="transform" type="translate" '
+                f'values="0 0; {width * 0.03:.2f} 0; 0 0" dur="{speed + 1.5:.2f}s" '
+                f'repeatCount="indefinite"/>'
+            )
+        paths_svg += (
+            f'  <path d="{mirror_path}" fill="{fill_color}" fill-opacity="{opacity * 0.4:.2f}">'
+            f'{mirror_anim}</path>\n'
+        )
 
     transform = f' transform="scale(1,-1) translate(0,-{height})"' if flip else ""
 

--- a/index.html
+++ b/index.html
@@ -482,6 +482,11 @@
         <label>Opacity (0–1)</label>
         <input type="number" id="opacity" value="1" min="0.1" max="1" step="0.05"/>
       </div>
+
+      <div class="ctrl">
+        <label>Animation Speed (s)</label>
+        <input type="number" id="speed" value="6" min="1" max="20" step="0.5"/>
+      </div>
     </div>
 
     <div class="toggles-row">
@@ -493,6 +498,9 @@
       </div>
       <div class="toggle-btn" id="toggle-mirror" onclick="toggle('mirror', this)">
         <span class="dot"></span> Mirror Ghost
+      </div>
+      <div class="toggle-btn" id="toggle-animate" onclick="toggle('animate', this)">
+        <span class="dot"></span> Wave Animation
       </div>
     </div>
 
@@ -521,9 +529,11 @@
 
 <script>
   // ─── State ───────────────────────────────────────────
-  const flags = { flip: false, gradient: false, mirror: false };
+  const flags = { flip: false, gradient: false, mirror: false, animate: true };
   let currentTab = 'markdown';
   let lastUrl = '';
+
+  document.getElementById('toggle-animate').classList.add('on');
 
   // ─── Color sync ──────────────────────────────────────
   function syncColor(pickerId, textId) {
@@ -551,7 +561,7 @@
     debTimer = setTimeout(generate, 300);
   }
 
-  ['type','width','height','amplitude','frequency','layers','opacity'].forEach(id => {
+  ['type','width','height','amplitude','frequency','layers','opacity','speed'].forEach(id => {
     document.getElementById(id).addEventListener('change', debounce);
     document.getElementById(id).addEventListener('input', debounce);
   });
@@ -571,6 +581,8 @@
       flip:         flags.flip,
       gradient:     flags.gradient,
       mirror:       flags.mirror,
+      animate:      flags.animate,
+      speed:        document.getElementById('speed').value,
     });
 
     const url = `/wave?${params}`;
@@ -670,11 +682,14 @@
     document.getElementById('color_bottom_picker').value = p.cb;
 
     // reset flags
-    ['flip','gradient','mirror'].forEach(f => {
+    ['flip','gradient','mirror','animate'].forEach(f => {
       flags[f] = false;
       document.getElementById(`toggle-${f}`).classList.remove('on');
       document.querySelector(`#toggle-${f} .dot`).style.background = '';
     });
+    flags.animate = true;
+    document.getElementById('toggle-animate').classList.add('on');
+
     if (p.flip) {
       flags.flip = true;
       document.getElementById('toggle-flip').classList.add('on');


### PR DESCRIPTION
### Motivation
- Add subtle motion to generated SVG waves so dividers can be animated and adjustable by users.

### Description
- Backend: added `animate` and `speed` parameters to `generate_wave_svg` and validated `speed`, then emitted SMIL `animateTransform` for each layer and the mirror layer when `animate` is enabled (`api/wavegen.py`).
- API: parsed `animate` and `speed` query params in the `/wave` endpoint and forwarded them to `generate_wave_svg` (`api/index.py`).
- UI: added a `Wave Animation` toggle and `Animation Speed (s)` input, sent `animate`/`speed` in the generator request, enabled animation by default for the live preview, and preserved animation state when applying presets (`index.html`).
- Kept existing behavior: layers, gradients, mirror and flip remain supported and animation integrates with those features.

### Testing
- Ran `python -m py_compile api/index.py api/wavegen.py` which succeeded.
- Launched the app with Flask and fetched the preview via the UI; the server started and the preview rendered (screenshot captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a062a9cb9c83318b313540f1ac918f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waves now animate dynamically with fully adjustable speed control
  * Animation enabled by default; toggle button to disable if preferred
  * Speed slider allows fine-tuning animation velocity across 1x to 20x range
  * Animation settings preserved in URLs for sharing wave configurations
  * Preset waves include appropriate animation settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->