### PR TITLE
Add top/bottom Wave Position selector to generator UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,6 +423,14 @@
       </div>
 
       <div class="ctrl">
+        <label>Wave Position</label>
+        <select id="position">
+          <option value="bottom" selected>Bottom</option>
+          <option value="top">Top (Upside Down)</option>
+        </select>
+      </div>
+
+      <div class="ctrl">
         <label>Width (px)</label>
         <input type="number" id="width" value="1200" min="200" max="2400" step="100"/>
       </div>
@@ -546,13 +554,17 @@
     debTimer = setTimeout(generate, 300);
   }
 
-  ['type','width','height','amplitude','frequency','layers','opacity','speed'].forEach(id => {
+  ['type','position','width','height','amplitude','frequency','layers','opacity','speed'].forEach(id => {
     document.getElementById(id).addEventListener('change', debounce);
     document.getElementById(id).addEventListener('input', debounce);
   });
 
   // ─── Generate ────────────────────────────────────────
   async function generate() {
+    const isTopPosition = document.getElementById('position').value === 'top';
+    flags.flip = isTopPosition;
+    document.getElementById('toggle-flip').classList.toggle('on', flags.flip);
+
     const params = new URLSearchParams({
       type:         document.getElementById('type').value,
       width:        document.getElementById('width').value,
@@ -676,6 +688,7 @@
 
   function applyPreset(p) {
     document.getElementById('type').value = p.type;
+    document.getElementById('position').value = p.flip ? 'top' : 'bottom';
     document.getElementById('amplitude').value = p.amp;
     document.getElementById('frequency').value = p.freq;
     document.getElementById('layers').value = p.layers;


### PR DESCRIPTION
### Motivation
- Provide an explicit UI control to choose whether the wave sits at the bottom or appears upside-down at the top, rather than relying only on the `Flip` toggle.

### Description
- Added a new `Wave Position` select control (`id="position"`) to `index.html` with `bottom` and `top` options. 
- Wired `position` into live updates by adding it to the debounce-list (`['type','position',... ]`) so changes update the preview immediately.
- Changed `generate()` to set `flags.flip` from the `position` selector and update the visual state of the `Flip` toggle so the backend still receives the `flip` query parameter.
- Made `applyPreset()` set the new `position` selector according to preset `flip` values to keep presets consistent.

### Testing
- Verified the `index.html` diff to confirm the UI and JS changes applied; this check succeeded.
- Started a local server with `python3 -m http.server 4173 --bind 0.0.0.0` and loaded the page to exercise the new control; the server ran and served the page.
- Automated UI check: used a Playwright script to select `#position` = `top` and capture a screenshot (`artifacts/wave-position-top.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08be747e883318d41d4beda8c8c53)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a Wave Position control allowing users to select between top and bottom wave placement
  * Wave position is now included in preset configuration and properly restored when applying saved presets
  * Real-time wave preview updates reflect position changes immediately

<!-- end of auto-generated comment: release notes by coderabbit.ai -->