### PR TITLE
Add .gitignore for Python and frontend artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.venv/
+venv/
+env/
+ENV/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+htmlcov/
+
+# Node / frontend tooling
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.dist/
+dist/
+
+# Local environment files
+.env
+.env.*
+!.env.example
+
+# IDE / editor settings
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
### Motivation
- Prevent accidental commits of common local/generated files such as Python caches and virtualenvs, frontend dependencies/build outputs, local `.env` files, editor settings, and OS artifacts.

### Description
- Add a root `.gitignore` containing rules for Python (`__pycache__/`, virtualenvs, test/tool caches, coverage), frontend (`node_modules/`, `dist/`, package-manager debug logs), local env files (`.env*`), IDE folders (`.vscode/`, `.idea/`) and OS files (`.DS_Store`, `Thumbs.db`).

### Testing
- Verified the `.gitignore` file was created and inspected its contents to ensure the expected ignore patterns are present and correctly formatted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a81e99755c83318df19a0f80993162)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `.gitignore` file to exclude Python, Node, IDE, OS, and cache artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->