### PR TITLE
Merging duplicates in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,14 +15,29 @@ ENV/
 .coverage.*
 htmlcov/
 
+# Python packaging/build artifacts
+build/
+dist/
+develop-eggs/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
 # Node / frontend tooling
 node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
-.dist/
-dist/
 
 # Local environment files
 .env
@@ -38,31 +53,3 @@ dist/
 # OS files
 .DS_Store
 Thumbs.db
-
-.env
-venv/
-env/
-__pycache__/
-*.py[cod]
-*$py.class
-.pytest_cache/
-.coverage
-htmlcov/
-.DS_Store
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-.vscode/
-.idea/


### PR DESCRIPTION
### Motivation
- Two concatenated sections were found in `.gitignore` in the repository, which led to duplicate rules and unnecessary noise.
- The goal is to have a single, clean, readable list of ignored files for Python, builds, and frontend tools.

### Description
- Removed duplicate lines and merged rules into a single structured configuration for Python, build artifacts, Node tools, environments, IDE settings, and system files.
- Added a separate section `# Python packaging/build artifacts` for build artifacts (`build/`, `dist/`, `*.egg`, etc.).
- Saved important exceptions such as `!.env.example` and standard entries for `node_modules/`, `.venv/`, `__pycache__/`, and `.DS_Store`.
- The `.gitignore` file has been reduced to a single list without repetitions and unnecessary lines.

### Testing
- The contents of the resulting file are checked using `nl -ba .gitignore`, and the file contains the expected merged rules (successful).
- The diff of the `.gitignore` file is reviewed to ensure that duplicates are removed and the necessary patterns are preserved (successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a942e007f48331af510d58b0ef3d3e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to improve build and development artifact management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->