### PR TITLE
Add overlay text style and X/Y scaling options

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -54,6 +54,9 @@ def wave():
     text      = request.args.get("text", "")[:120]
     text_color = "#" + request.args.get("text_color", "ffffff").lstrip("#")
     text_size = min(max(int(request.args.get("text_size", 28)), 8), 180)
+    text_style = request.args.get("text_style", "normal").lower()
+    text_scale_x = min(max(float(request.args.get("text_scale_x", 100)), 50), 200)
+    text_scale_y = min(max(float(request.args.get("text_scale_y", 100)), 50), 200)
     text_x    = min(max(float(request.args.get("text_x", 50)), 0), 100)
     text_y    = min(max(float(request.args.get("text_y", 45)), 0), 100)
     text_align = request.args.get("text_align", "middle").lower()
@@ -76,6 +79,9 @@ def wave():
         text=text,
         text_color=text_color,
         text_size=text_size,
+        text_style=text_style,
+        text_scale_x=text_scale_x,
+        text_scale_y=text_scale_y,
         text_x=text_x,
         text_y=text_y,
         text_align=text_align,

--- a/api/wavegen.py
+++ b/api/wavegen.py
@@ -234,6 +234,9 @@ def generate_wave_svg(
     text: str = "",
     text_color: str = "#ffffff",
     text_size: int = 28,
+    text_style: str = "normal",
+    text_scale_x: float = 100.0,
+    text_scale_y: float = 100.0,
     text_x: float = 50.0,
     text_y: float = 45.0,
     text_align: str = "middle",
@@ -249,9 +252,12 @@ def generate_wave_svg(
     opacity = min(max(opacity, 0.1), 1.0)
     speed = min(max(speed, 1.0), 20.0)
     text_size = min(max(int(text_size), 8), 180)
+    text_scale_x = min(max(float(text_scale_x), 50.0), 200.0)
+    text_scale_y = min(max(float(text_scale_y), 50.0), 200.0)
     text_x = min(max(float(text_x), 0.0), 100.0)
     text_y = min(max(float(text_y), 0.0), 100.0)
     text_align = text_align if text_align in ("start", "middle", "end") else "middle"
+    text_style = text_style if text_style in ("normal", "bold", "italic", "bold_italic") else "normal"
     text = text.strip()
 
     r1, g1, b1 = _hex_to_rgb(color_top)
@@ -479,9 +485,16 @@ def generate_wave_svg(
 
     text_svg = ""
     if text:
+        font_weight = "700" if text_style in ("bold", "bold_italic") else "400"
+        font_style = "italic" if text_style in ("italic", "bold_italic") else "normal"
+        text_pos_x = width * text_x / 100
+        text_pos_y = height * text_y / 100
+        scale_x = text_scale_x / 100
+        scale_y = text_scale_y / 100
         text_svg = (
-            f'  <text x="{(width * text_x / 100):.2f}" y="{(height * text_y / 100):.2f}" '
+            f'  <text x="0" y="0" transform="translate({text_pos_x:.2f} {text_pos_y:.2f}) scale({scale_x:.2f} {scale_y:.2f})" '
             f'fill="{_esc(text_color)}" font-size="{text_size}" text-anchor="{text_align}" '
+            f'font-weight="{font_weight}" font-style="{font_style}" '
             f'font-family="Inter,Segoe UI,Roboto,Arial,sans-serif" dominant-baseline="middle">'
             f'{_esc(text)}</text>\n'
         )

--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ function debounce() {
   debTimer = setTimeout(generate, 300);
 }
 
-['type','position','width','height','amplitude','frequency','layers','opacity','speed','text_content','text_size','text_x','text_y','text_align'].forEach(id => {
+['type','position','width','height','amplitude','frequency','layers','opacity','speed','text_content','text_size','text_style','text_scale_x','text_scale_y','text_x','text_y','text_align'].forEach(id => {
   document.getElementById(id).addEventListener('change', debounce);
   document.getElementById(id).addEventListener('input', debounce);
 });
@@ -61,6 +61,9 @@ async function generate() {
     text:         document.getElementById('text_content').value,
     text_color:   document.getElementById('text_color').value.replace('#',''),
     text_size:    document.getElementById('text_size').value,
+    text_style:   document.getElementById('text_style').value,
+    text_scale_x: document.getElementById('text_scale_x').value,
+    text_scale_y: document.getElementById('text_scale_y').value,
     text_x:       document.getElementById('text_x').value,
     text_y:       document.getElementById('text_y').value,
     text_align:   document.getElementById('text_align').value,

--- a/index.html
+++ b/index.html
@@ -138,6 +138,26 @@
       </div>
 
       <div class="ctrl">
+        <label>Text Style</label>
+        <select id="text_style">
+          <option value="normal" selected>Normal</option>
+          <option value="bold">Bold</option>
+          <option value="italic">Italic</option>
+          <option value="bold_italic">Bold Italic</option>
+        </select>
+      </div>
+
+      <div class="ctrl">
+        <label>Text Scale X (%)</label>
+        <input type="number" id="text_scale_x" value="100" min="50" max="200"/>
+      </div>
+
+      <div class="ctrl">
+        <label>Text Scale Y (%)</label>
+        <input type="number" id="text_scale_y" value="100" min="50" max="200"/>
+      </div>
+
+      <div class="ctrl">
         <label>Text X Position (%)</label>
         <input type="number" id="text_x" value="50" min="0" max="100"/>
       </div>


### PR DESCRIPTION
### Motivation
- Allow choosing text style (normal / bold / italic / bold_italic) and independently scale overlay text horizontally and vertically so users can make text wider or taller over the generated wave.

### Description
- Added UI controls in `index.html` for `Text Style`, `Text Scale X (%)`, and `Text Scale Y (%)` and kept them within the existing control grid.  
- Wired the new controls into `app.js` so their values are included in the live preview request as `text_style`, `text_scale_x`, and `text_scale_y`.  
- Extended the `/wave` endpoint parsing in `api/index.py` to accept and validate `text_style`, `text_scale_x`, and `text_scale_y` before passing them to the generator.  
- Updated `api/wavegen.py` to validate the new parameters, map `text_style` to `font-weight`/`font-style`, and apply independent axis scaling via `transform="translate(...) scale(... ...)"` when rendering the SVG `<text>` element.

### Testing
- Ran `python -m py_compile api/index.py api/wavegen.py` and it completed successfully.  
- Executed a small generation check: called `generate_wave_svg(text='Demo', text_style='bold_italic', text_scale_x=140, text_scale_y=80)` and verified the output contains the expected `font-weight`, `font-style`, and `scale(...)` transform strings (test passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeb24c861c8331bf351d374b57424e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text styling options including normal, bold, italic, and bold italic variants.
  * Added independent horizontal and vertical text scaling controls with a configurable range of 50-200%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->