### PR TITLE
Add configurable text outline (stroke) for overlay text

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -55,6 +55,8 @@ def wave():
     text_color = "#" + request.args.get("text_color", "ffffff").lstrip("#")
     text_size = min(max(int(request.args.get("text_size", 28)), 8), 180)
     text_style = request.args.get("text_style", "normal").lower()
+    text_stroke_color = "#" + request.args.get("text_stroke_color", "000000").lstrip("#")
+    text_stroke_width = min(max(float(request.args.get("text_stroke_width", 0)), 0), 20)
     text_scale_x = min(max(float(request.args.get("text_scale_x", 100)), 50), 200)
     text_scale_y = min(max(float(request.args.get("text_scale_y", 100)), 50), 200)
     text_x    = min(max(float(request.args.get("text_x", 50)), 0), 100)
@@ -80,6 +82,8 @@ def wave():
         text_color=text_color,
         text_size=text_size,
         text_style=text_style,
+        text_stroke_color=text_stroke_color,
+        text_stroke_width=text_stroke_width,
         text_scale_x=text_scale_x,
         text_scale_y=text_scale_y,
         text_x=text_x,

--- a/api/wavegen.py
+++ b/api/wavegen.py
@@ -235,6 +235,8 @@ def generate_wave_svg(
     text_color: str = "#ffffff",
     text_size: int = 28,
     text_style: str = "normal",
+    text_stroke_color: str = "#000000",
+    text_stroke_width: float = 0.0,
     text_scale_x: float = 100.0,
     text_scale_y: float = 100.0,
     text_x: float = 50.0,
@@ -258,6 +260,7 @@ def generate_wave_svg(
     text_y = min(max(float(text_y), 0.0), 100.0)
     text_align = text_align if text_align in ("start", "middle", "end") else "middle"
     text_style = text_style if text_style in ("normal", "bold", "italic", "bold_italic") else "normal"
+    text_stroke_width = min(max(float(text_stroke_width), 0.0), 20.0)
     text = text.strip()
 
     r1, g1, b1 = _hex_to_rgb(color_top)
@@ -495,7 +498,9 @@ def generate_wave_svg(
             f'  <text x="0" y="0" transform="translate({text_pos_x:.2f} {text_pos_y:.2f}) scale({scale_x:.2f} {scale_y:.2f})" '
             f'fill="{_esc(text_color)}" font-size="{text_size}" text-anchor="{text_align}" '
             f'font-weight="{font_weight}" font-style="{font_style}" '
-            f'font-family="Inter,Segoe UI,Roboto,Arial,sans-serif" dominant-baseline="middle">'
+            f'font-family="Inter,Segoe UI,Roboto,Arial,sans-serif" dominant-baseline="middle" '
+            f'stroke="{_esc(text_stroke_color)}" stroke-width="{text_stroke_width:.2f}" '
+            f'paint-order="stroke fill">'
             f'{_esc(text)}</text>\n'
         )
 

--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ function syncColor(pickerId, textId) {
 syncColor('color_top_picker', 'color_top');
 syncColor('color_bottom_picker', 'color_bottom');
 syncColor('text_color_picker', 'text_color');
+syncColor('text_stroke_color_picker', 'text_stroke_color');
 
 // Toggle controls
 function toggle(key, el) {
@@ -32,7 +33,7 @@ function debounce() {
   debTimer = setTimeout(generate, 300);
 }
 
-['type','position','width','height','amplitude','frequency','layers','opacity','speed','text_content','text_size','text_style','text_scale_x','text_scale_y','text_x','text_y','text_align'].forEach(id => {
+['type','position','width','height','amplitude','frequency','layers','opacity','speed','text_content','text_size','text_style','text_scale_x','text_scale_y','text_x','text_y','text_align','text_stroke_width'].forEach(id => {
   document.getElementById(id).addEventListener('change', debounce);
   document.getElementById(id).addEventListener('input', debounce);
 });
@@ -62,6 +63,8 @@ async function generate() {
     text_color:   document.getElementById('text_color').value.replace('#',''),
     text_size:    document.getElementById('text_size').value,
     text_style:   document.getElementById('text_style').value,
+    text_stroke_color: document.getElementById('text_stroke_color').value.replace('#',''),
+    text_stroke_width: document.getElementById('text_stroke_width').value,
     text_scale_x: document.getElementById('text_scale_x').value,
     text_scale_y: document.getElementById('text_scale_y').value,
     text_x:       document.getElementById('text_x').value,

--- a/index.html
+++ b/index.html
@@ -133,6 +133,19 @@
       </div>
 
       <div class="ctrl">
+        <label>Text Outline Color</label>
+        <div class="color-pair">
+          <input type="color" id="text_stroke_color_picker" value="#000000"/>
+          <input type="text" id="text_stroke_color" value="#000000"/>
+        </div>
+      </div>
+
+      <div class="ctrl">
+        <label>Text Outline Width (px)</label>
+        <input type="number" id="text_stroke_width" value="0" min="0" max="20" step="0.5"/>
+      </div>
+
+      <div class="ctrl">
         <label>Text Size (px)</label>
         <input type="number" id="text_size" value="28" min="8" max="180"/>
       </div>


### PR DESCRIPTION
### Motivation
- Provide an option to add an outline (stroke) to overlay text so it remains legible on variable wave backgrounds.

### Description
- Added UI controls `Text Outline Color` and `Text Outline Width (px)` in `index.html` and wired their color pickers/text inputs to the sync logic. (`index.html`, `app.js`).
- Sent `text_stroke_color` and `text_stroke_width` from the frontend as query parameters in `/wave` requests. (`app.js`).
- Extended the API to parse `text_stroke_color` and `text_stroke_width`, clamp values, and forward them to the SVG generator. (`api/index.py`).
- Updated `generate_wave_svg` signature to accept `text_stroke_color` and `text_stroke_width`, sanitize/clamp `text_stroke_width`, and render the `<text>` element with `stroke`, `stroke-width`, and `paint-order="stroke fill"` so the outline appears behind the fill. (`api/wavegen.py`).

### Testing
- Ran `python -m compileall api` to ensure modules compile successfully (succeeded).
- Executed a quick generation check with `from api.wavegen import generate_wave_svg` and confirmed the produced SVG contains `stroke`, `stroke-width` and `paint-order` attributes (succeeded).
- Launched the local Flask server and performed a manual UI validation via an automated Playwright screenshot to confirm the preview updates with outline settings (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aebbaa52588331a1160d8c138c7a26)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added text outline customization with controls for stroke color and stroke width (0.0 to 20.0 px), allowing enhanced text styling in wave generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->