### PR TITLE
Fix preview rendering to match README embed

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,11 +77,10 @@ async function generate() {
 
   document.getElementById('loading-bar').classList.add('active');
 
-  // Fetch inline SVG for preview updates
+  // Render preview exactly like README embeds via <img>
   try {
-    const resp = await fetch(url);
-    const svg = await resp.text();
-    document.getElementById('preview-wrap').innerHTML = svg;
+    const previewUrl = `${url}&_preview_ts=${Date.now()}`;
+    document.getElementById('preview-wrap').innerHTML = `<img src="${previewUrl}" alt="Wave preview" style="width:100%;height:auto;display:block;" />`;
   } catch(e) {}
 
   document.getElementById('loading-bar').classList.remove('active');


### PR DESCRIPTION
### Motivation
- The in-page preview injected inline SVG which rendered differently than the README/Markdown embed, causing a visual mismatch.

### Description
- Update `app.js` to render the live preview using an `<img src="...">` (with a `_preview_ts` cache-busting query param) instead of fetching and injecting inline SVG so the preview matches README embeds.

### Testing
- Ran `node --check app.js` and `python -m py_compile api/index.py api/wavegen.py`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec09fc2488331a3ca35fd74454200)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the preview refresh mechanism to ensure previews render correctly and display the latest changes without caching issues. The preview update process now includes improved cache-busting timestamp functionality, preventing stale preview content from appearing and guaranteeing that users always view the most current and accurate preview state after making changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->