### PR TITLE
Add support for independent top and bottom overlay texts

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -52,8 +52,11 @@ def wave():
     animate   = request.args.get("animate", "false").lower() == "true"
     speed     = min(max(float(request.args.get("speed", 6)), 1), 20)
     text      = request.args.get("text", "")[:120]
+    text_bottom = request.args.get("text_bottom", "")[:120]
     text_color = "#" + request.args.get("text_color", "ffffff").lstrip("#")
+    text_bottom_color = "#" + request.args.get("text_bottom_color", "a5b4fc").lstrip("#")
     text_size = min(max(int(request.args.get("text_size", 28)), 8), 180)
+    text_bottom_size = min(max(int(request.args.get("text_bottom_size", 22)), 8), 180)
     text_style = request.args.get("text_style", "normal").lower()
     text_stroke_color = "#" + request.args.get("text_stroke_color", "000000").lstrip("#")
     text_stroke_width = min(max(float(request.args.get("text_stroke_width", 0)), 0), 20)
@@ -61,6 +64,7 @@ def wave():
     text_scale_y = min(max(float(request.args.get("text_scale_y", 100)), 50), 200)
     text_x    = min(max(float(request.args.get("text_x", 50)), 0), 100)
     text_y    = min(max(float(request.args.get("text_y", 45)), 0), 100)
+    text_gap  = min(max(float(request.args.get("text_gap", 26)), 0), 200)
     text_align = request.args.get("text_align", "middle").lower()
 
     svg = generate_wave_svg(
@@ -79,8 +83,11 @@ def wave():
         animate=animate,
         speed=speed,
         text=text,
+        text_bottom=text_bottom,
         text_color=text_color,
+        text_bottom_color=text_bottom_color,
         text_size=text_size,
+        text_bottom_size=text_bottom_size,
         text_style=text_style,
         text_stroke_color=text_stroke_color,
         text_stroke_width=text_stroke_width,
@@ -88,6 +95,7 @@ def wave():
         text_scale_y=text_scale_y,
         text_x=text_x,
         text_y=text_y,
+        text_gap=text_gap,
         text_align=text_align,
     )
 

--- a/api/wavegen.py
+++ b/api/wavegen.py
@@ -232,8 +232,11 @@ def generate_wave_svg(
     speed: float = 6.0,
     smooth: bool = True,
     text: str = "",
+    text_bottom: str = "",
     text_color: str = "#ffffff",
+    text_bottom_color: str = "#a5b4fc",
     text_size: int = 28,
+    text_bottom_size: int = 22,
     text_style: str = "normal",
     text_stroke_color: str = "#000000",
     text_stroke_width: float = 0.0,
@@ -241,6 +244,7 @@ def generate_wave_svg(
     text_scale_y: float = 100.0,
     text_x: float = 50.0,
     text_y: float = 45.0,
+    text_gap: float = 26.0,
     text_align: str = "middle",
 ) -> str:
     """
@@ -254,14 +258,17 @@ def generate_wave_svg(
     opacity = min(max(opacity, 0.1), 1.0)
     speed = min(max(speed, 1.0), 20.0)
     text_size = min(max(int(text_size), 8), 180)
+    text_bottom_size = min(max(int(text_bottom_size), 8), 180)
     text_scale_x = min(max(float(text_scale_x), 50.0), 200.0)
     text_scale_y = min(max(float(text_scale_y), 50.0), 200.0)
     text_x = min(max(float(text_x), 0.0), 100.0)
     text_y = min(max(float(text_y), 0.0), 100.0)
+    text_gap = min(max(float(text_gap), 0.0), 200.0)
     text_align = text_align if text_align in ("start", "middle", "end") else "middle"
     text_style = text_style if text_style in ("normal", "bold", "italic", "bold_italic") else "normal"
     text_stroke_width = min(max(float(text_stroke_width), 0.0), 20.0)
     text = text.strip()
+    text_bottom = text_bottom.strip()
 
     r1, g1, b1 = _hex_to_rgb(color_top)
     r2, g2, b2 = _hex_to_rgb(color_bottom)
@@ -487,22 +494,34 @@ def generate_wave_svg(
         )
 
     text_svg = ""
-    if text:
+    if text or text_bottom:
         font_weight = "700" if text_style in ("bold", "bold_italic") else "400"
         font_style = "italic" if text_style in ("italic", "bold_italic") else "normal"
         text_pos_x = width * text_x / 100
         text_pos_y = height * text_y / 100
+        text_bottom_pos_y = text_pos_y + text_gap
         scale_x = text_scale_x / 100
         scale_y = text_scale_y / 100
-        text_svg = (
-            f'  <text x="0" y="0" transform="translate({text_pos_x:.2f} {text_pos_y:.2f}) scale({scale_x:.2f} {scale_y:.2f})" '
-            f'fill="{_esc(text_color)}" font-size="{text_size}" text-anchor="{text_align}" '
-            f'font-weight="{font_weight}" font-style="{font_style}" '
-            f'font-family="Inter,Segoe UI,Roboto,Arial,sans-serif" dominant-baseline="middle" '
-            f'stroke="{_esc(text_stroke_color)}" stroke-width="{text_stroke_width:.2f}" '
-            f'paint-order="stroke fill">'
-            f'{_esc(text)}</text>\n'
-        )
+        if text:
+            text_svg += (
+                f'  <text x="0" y="0" transform="translate({text_pos_x:.2f} {text_pos_y:.2f}) scale({scale_x:.2f} {scale_y:.2f})" '
+                f'fill="{_esc(text_color)}" font-size="{text_size}" text-anchor="{text_align}" '
+                f'font-weight="{font_weight}" font-style="{font_style}" '
+                f'font-family="Inter,Segoe UI,Roboto,Arial,sans-serif" dominant-baseline="middle" '
+                f'stroke="{_esc(text_stroke_color)}" stroke-width="{text_stroke_width:.2f}" '
+                f'paint-order="stroke fill">'
+                f'{_esc(text)}</text>\n'
+            )
+        if text_bottom:
+            text_svg += (
+                f'  <text x="0" y="0" transform="translate({text_pos_x:.2f} {text_bottom_pos_y:.2f}) scale({scale_x:.2f} {scale_y:.2f})" '
+                f'fill="{_esc(text_bottom_color)}" font-size="{text_bottom_size}" text-anchor="{text_align}" '
+                f'font-weight="{font_weight}" font-style="{font_style}" '
+                f'font-family="Inter,Segoe UI,Roboto,Arial,sans-serif" dominant-baseline="middle" '
+                f'stroke="{_esc(text_stroke_color)}" stroke-width="{text_stroke_width:.2f}" '
+                f'paint-order="stroke fill">'
+                f'{_esc(text_bottom)}</text>\n'
+            )
 
     return f"""<svg xmlns="http://www.w3.org/2000/svg"
      viewBox="0 0 {width} {height}" width="{width}" height="{height}"

--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ function syncColor(pickerId, textId) {
 syncColor('color_top_picker', 'color_top');
 syncColor('color_bottom_picker', 'color_bottom');
 syncColor('text_color_picker', 'text_color');
+syncColor('text_bottom_color_picker', 'text_bottom_color');
 syncColor('text_stroke_color_picker', 'text_stroke_color');
 
 // Toggle controls
@@ -33,7 +34,7 @@ function debounce() {
   debTimer = setTimeout(generate, 300);
 }
 
-['type','position','width','height','amplitude','frequency','layers','opacity','speed','text_content','text_size','text_style','text_scale_x','text_scale_y','text_x','text_y','text_align','text_stroke_width'].forEach(id => {
+['type','position','width','height','amplitude','frequency','layers','opacity','speed','text_content','text_bottom_content','text_size','text_bottom_size','text_style','text_scale_x','text_scale_y','text_x','text_y','text_gap','text_align','text_stroke_width'].forEach(id => {
   document.getElementById(id).addEventListener('change', debounce);
   document.getElementById(id).addEventListener('input', debounce);
 });
@@ -60,8 +61,11 @@ async function generate() {
     animate:      flags.animate,
     speed:        document.getElementById('speed').value,
     text:         document.getElementById('text_content').value,
+    text_bottom:  document.getElementById('text_bottom_content').value,
     text_color:   document.getElementById('text_color').value.replace('#',''),
+    text_bottom_color: document.getElementById('text_bottom_color').value.replace('#',''),
     text_size:    document.getElementById('text_size').value,
+    text_bottom_size: document.getElementById('text_bottom_size').value,
     text_style:   document.getElementById('text_style').value,
     text_stroke_color: document.getElementById('text_stroke_color').value.replace('#',''),
     text_stroke_width: document.getElementById('text_stroke_width').value,
@@ -69,6 +73,7 @@ async function generate() {
     text_scale_y: document.getElementById('text_scale_y').value,
     text_x:       document.getElementById('text_x').value,
     text_y:       document.getElementById('text_y').value,
+    text_gap:     document.getElementById('text_gap').value,
     text_align:   document.getElementById('text_align').value,
   });
 

--- a/index.html
+++ b/index.html
@@ -120,15 +120,28 @@
       </div>
 
       <div class="ctrl">
-        <label>Overlay Text</label>
-        <input type="text" id="text_content" value="" placeholder="Type text over the wave" maxlength="120"/>
+        <label>Top Text</label>
+        <input type="text" id="text_content" value="" placeholder="Top text" maxlength="120"/>
       </div>
 
       <div class="ctrl">
-        <label>Text Color</label>
+        <label>Bottom Text</label>
+        <input type="text" id="text_bottom_content" value="" placeholder="Bottom text" maxlength="120"/>
+      </div>
+
+      <div class="ctrl">
+        <label>Top Text Color</label>
         <div class="color-pair">
           <input type="color" id="text_color_picker" value="#ffffff"/>
           <input type="text" id="text_color" value="#ffffff"/>
+        </div>
+      </div>
+
+      <div class="ctrl">
+        <label>Bottom Text Color</label>
+        <div class="color-pair">
+          <input type="color" id="text_bottom_color_picker" value="#a5b4fc"/>
+          <input type="text" id="text_bottom_color" value="#a5b4fc"/>
         </div>
       </div>
 
@@ -146,8 +159,13 @@
       </div>
 
       <div class="ctrl">
-        <label>Text Size (px)</label>
+        <label>Top Text Size (px)</label>
         <input type="number" id="text_size" value="28" min="8" max="180"/>
+      </div>
+
+      <div class="ctrl">
+        <label>Bottom Text Size (px)</label>
+        <input type="number" id="text_bottom_size" value="22" min="8" max="180"/>
       </div>
 
       <div class="ctrl">
@@ -178,6 +196,11 @@
       <div class="ctrl">
         <label>Text Y Position (%)</label>
         <input type="number" id="text_y" value="45" min="0" max="100"/>
+      </div>
+
+      <div class="ctrl">
+        <label>Text Gap (px)</label>
+        <input type="number" id="text_gap" value="26" min="0" max="200"/>
       </div>
 
       <div class="ctrl">


### PR DESCRIPTION
### Motivation
- Add the ability to place two independent text lines above the wave divider (top and bottom) with separate colors, sizes, and spacing.

### Description
- UI: Added fields to `index.html` — `Top Text`, `Bottom Text`, `Top Text Color`, `Bottom Text Color`, `Top Text Size`, `Bottom Text Size`, and `Text Gap (px)` to control the spacing between lines. (`index.html`)
- Frontend: Synced new color pickovers, subscribed new fields to debounce updates, and included new parameters in the generated URL (`text_bottom`, `text_bottom_color`, `text_bottom_size`, `text_gap`). (`app.js`)
- API: The `/wave` handler has been extended to read and validate new query parameters and pass them to the SVG generator. (`api/index.py`)
- SVG generator: `generate_wave_svg` in `api/wavegen.py` now supports `text_bottom` with separate default values, size validation, and `text_gap` positioning; the text is rendered as two separate `<text>` elements with shared styles (alignment, weight, style, and border).

### Testing
- Python modules compiled successfully: `python -m py_compile api/index.py api/wavegen.py` (ok).
- JS static check successful: `node --check app.js` (ok).
- Generator functional check: A one-line Python script was run that calls `generate_wave_svg(text='Top', text_bottom='Bottom', text_gap=30, text_color='#ffffff', text_bottom_color='#00ff00')` and checks for the presence of both `</text>` tags in the result (ok).
- An attempt was made to take a screenshot of the page via Playwright, but the artifact was unsuccessful due to issues accessing the page in the browser container (timeout/`Not Found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec4f9c9508331ba3134647d2380b8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features** 
* Added support for a second text line below the wave with customizable content, color, and size. 
* Introduced Text Gap control to adjust spacing between top and bottom text. 
* Renamed "Overlay Text" to "Top Text" for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->